### PR TITLE
ゲームアツマール上でスキルツリー利用時にエラーを起こさないように修正

### DIFF
--- a/SkillTree.js
+++ b/SkillTree.js
@@ -1216,7 +1216,7 @@ class SkillTreeManager {
     }
 
     changeNextNode() {
-        parent = this._selectNode.parent(0);
+        const parent = this._selectNode.parent(0);
         if (!parent) throw new Error("Unknown parent");
         const i = parent.childs().indexOf(this._selectNode);
         const nextNode = parent.child(i + 1);
@@ -1228,7 +1228,7 @@ class SkillTreeManager {
     }
 
     changePrevNode() {
-        parent = this._selectNode.parent(0);
+        const parent = this._selectNode.parent(0);
         if (!parent) throw new Error("Unknown parent");
         const i = parent.childs().indexOf(this._selectNode);
         const nextNode = parent.child(i - 1);


### PR DESCRIPTION
ご無沙汰しております、プラグイン作家のくらむぼんです。

このところスキルツリープラグイン利用時に「ゲームアツマールで遊んでいる時はエラーになる」という状況を確認しておりまして、調べましたところグローバル変数の parent がこのプラグインで上書きされてiframeを用いるWebサイトの parent へのアクセスが失われていることに起因するとわかりました。
（つまり今回はアツマールで顕在化しましたが、同様にiframeを用いるふりーむやPlicyでもいつ不具合が起こるかわからない状態）

おそらくここは単にローカル変数として用いたかっただけだと思いますので、 const を追加するこの提案をマージしていただければ直ると思います。
どうぞよろしくお願いします 🙏 